### PR TITLE
Fix: Correct SyntaxError in handlers/common.py

### DIFF
--- a/handlers/common.py
+++ b/handlers/common.py
@@ -62,6 +62,10 @@ async def route_text_message_by_state(update: Update, context: ContextTypes.DEFA
     try:
         # --- PASO 1: DIRIGIR SEGÚN ESTADO ---
         from . import turno, receta, misc
+    except ImportError as e:
+        logger.critical(f"Failed to import state handlers (turno, receta, misc): {e}", exc_info=True)
+        await update.message.reply_text("Ocurrió un error interno al procesar tu solicitud. Por favor, intenta más tarde.")
+        return # Exit the function if imports fail
 
     state_handlers = {
         config.STATE_WAITING_DOCTOR: turno.handle_turno_solicitar_doctor,


### PR DESCRIPTION
A try block for importing state-specific handlers (turno, receta, misc) in the `route_text_message_by_state` function was missing its corresponding `except` or `finally` clause. This caused a SyntaxError when the `state_handlers` dictionary was defined immediately after it.

This commit adds an `except ImportError` block to handle potential failures during these imports and ensures the `state_handlers` dictionary is defined outside and after this try-except block, resolving the syntax error.